### PR TITLE
Fix for flex-direction

### DIFF
--- a/_scss/_blog.scss
+++ b/_scss/_blog.scss
@@ -46,6 +46,7 @@
 .disqus {
   border-top: 2px solid #f4f6f6;
   background-color: #fafafa;
+  flex: 1 0 auto;
   margin-top: 11%;
   padding-top: 3.5%;
   padding-bottom: 4%;

--- a/_scss/_footer.scss
+++ b/_scss/_footer.scss
@@ -9,7 +9,8 @@
   color: $gray04;
   border-top: 1px dashed $gray02;
   background-color: $pure-white;
-    
+  flex: 1 0 auto;
+
 
     @include mobile {
     margin-top: 50px;


### PR DESCRIPTION
In Safari (and in Chrome to a lesser degree), setting flex-direction on a parent container and not specifically setting flex-basis and flex-grow can cause layout bugs. I believe this is a result of a poor
implementation of flex-direction by Safari/WebKit. But the fix works cross-browser.

Tested in Safari 9.0.2 on OS X, Safari 9.0.2 on iOS, latest Firefox, latest Chrome.
